### PR TITLE
feat : fetchClubsByLeague API & utils function, type

### DIFF
--- a/api/nest-api/src/application/club-cases/club.controller.ts
+++ b/api/nest-api/src/application/club-cases/club.controller.ts
@@ -1,5 +1,6 @@
-import { Controller, Get } from "@nestjs/common";
+import { Controller, Get, Param } from "@nestjs/common";
 import { ClubService } from "./club.service";
+import { LeagueType } from "src/infrastructure/types/league.type";
 
 @Controller('club')
 export class ClubController {
@@ -8,5 +9,10 @@ export class ClubController {
     @Get('listup')
     listup() {
         return this.clubService.listUpAllClubs();
+    }
+
+    @Get(':league')
+    fetchClubsByLeague(@Param('league') league: LeagueType) {
+        return this.clubService.fetchClubsByLeague(league);
     }
 }

--- a/api/nest-api/src/application/club-cases/club.service.ts
+++ b/api/nest-api/src/application/club-cases/club.service.ts
@@ -1,6 +1,8 @@
 import { Injectable } from "@nestjs/common";
 import { PrismaService } from "src/domain/prisma/prisma.service";
-import { Club } from '@prisma/client';
+import { LeagueType } from "src/infrastructure/types/league.type";
+import { NumEachLeague } from "src/infrastructure/types/league.type";
+import { SerializeBigInt } from "src/infrastructure/utils/serialize";
 
 @Injectable({})
 export class ClubService {
@@ -10,9 +12,22 @@ export class ClubService {
         try {
             const clubs = await this.prisma.club.findMany();
             // BigInt を文字列に変換してから返す
-            return JSON.parse(JSON.stringify(clubs, (key, value) =>
-                typeof value === 'bigint' ? value.toString() : value
-            ));
+            return SerializeBigInt.serialize(clubs);
+        } catch (error) {
+            console.error('Error fetching clubs:', error);
+            throw error;
+        }
+    }
+
+    async fetchClubsByLeague(league: LeagueType) {
+        try {
+            const leagueNum: number = NumEachLeague[`${league}`];
+            const clubs = await this.prisma.club.findMany({
+                where: {
+                    league_id: leagueNum
+                }
+            });
+            return SerializeBigInt.serialize(clubs);
         } catch (error) {
             console.error('Error fetching clubs:', error);
             throw error;

--- a/api/nest-api/src/infrastructure/types/league.type.ts
+++ b/api/nest-api/src/infrastructure/types/league.type.ts
@@ -1,0 +1,10 @@
+export type LeagueType = 'J1League' | 'PremierLeague' | 'LaLiga' | 'serieA' | 'Bundesliga' | 'Ligue1';
+
+export const NumEachLeague = {
+    'J1League': 1,
+    'PremierLeague': 2,
+    'LaLiga': 3,
+    'serieA': 4,
+    'Bundesliga': 5,
+    'Ligue1': 6
+}

--- a/api/nest-api/src/infrastructure/utils/serialize.ts
+++ b/api/nest-api/src/infrastructure/utils/serialize.ts
@@ -1,0 +1,12 @@
+export class SerializeBigInt {
+    public static serialize<T>(input: T): T {
+        return JSON.parse(JSON.stringify(input, this.replacer));
+    }
+
+    private static replacer(key: string, value: any): any {
+        if (typeof value === 'bigint') {
+            return value.toString();
+        }
+        return value;
+    }
+}


### PR DESCRIPTION
クラブのパスパラメータに従ってクラブを取得するAPIを作成しました。
また、共通した処理、型をまとめました。
infrastructure/utils, types内のパスです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 利用者が指定したリーグ（例: J1League、PremierLeague、LaLiga、serieA、Bundesliga、Ligue1）のクラブ情報を取得できる新たなAPIエンドポイントを追加しました。
  - 数値データの処理とエラー管理の改善により、より安定してクラブ情報を提供できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->